### PR TITLE
Changed method in Chatline to allow whitespace

### DIFF
--- a/app/src/main/java/de/kuschku/quasseldroid/ui/chat/input/ChatlineFragment.kt
+++ b/app/src/main/java/de/kuschku/quasseldroid/ui/chat/input/ChatlineFragment.kt
@@ -165,7 +165,7 @@ class ChatlineFragment : ServiceBoundFragment() {
       .observe(this, Observer(messageHistoryAdapter::submitList))
 
     fun send() {
-      if (chatline.text.isNotBlank()) {
+      if (chatline.text.isNotEmpty()) {
         val lines = chatline.text.lineSequence().map {
           SpannableString(it).apply {
             for (span in getSpans(0, length, Any::class.java)) {
@@ -221,7 +221,7 @@ class ChatlineFragment : ServiceBoundFragment() {
   }
 
   fun replaceText(text: CharSequence) {
-    if (chatline.text.isNotBlank()) {
+    if (chatline.text.isNotEmpty()) {
       chatline.text.lineSequence().forEach(viewModel::addRecentlySentMessage)
     }
     editorHelper.replaceText(text)


### PR DESCRIPTION
Changed the method from `isNotBlank`to `isNotEmpty`. This allows the
user to send an empty character like a single space.