### PR TITLE
Fix and unify implementation of HostmaskHelper

### DIFF
--- a/lib/src/main/java/de/kuschku/libquassel/util/irc/HostmaskHelper.kt
+++ b/lib/src/main/java/de/kuschku/libquassel/util/irc/HostmaskHelper.kt
@@ -20,26 +20,23 @@
 package de.kuschku.libquassel.util.irc
 
 object HostmaskHelper {
-  fun nick(mask: String) = mask
-    .substringBefore('!', missingDelimiterValue = mask)
+  fun nick(mask: String) = split(mask).first
 
-  fun user(mask: String) = mask
-    .substringBeforeLast('@', missingDelimiterValue = mask)
-    .substringAfter('!', missingDelimiterValue = "")
+  fun user(mask: String) = split(mask).second
 
-  fun host(mask: String) = mask
-    .substringAfterLast('@', missingDelimiterValue = "")
+  fun host(mask: String) = split(mask).third
 
   fun split(mask: String): Triple<String, String, String> {
-    val userPartHostSplit = mask.split("@", limit = 2)
-    if (userPartHostSplit.size < 2)
+    val atIndex = mask.lastIndexOf('@')
+    if (atIndex == -1)
       return Triple(mask, "", "")
 
-    val (userPart, host) = userPartHostSplit
+    val host = mask.substring(atIndex + 1)
+    val userPart = mask.substring(0, atIndex)
 
     val nickUserSplit = userPart.split('!', limit = 2)
     if (nickUserSplit.size < 2)
-      return Triple(mask, "", host)
+      return Triple(userPart, "", host)
 
     val (nick, user) = nickUserSplit
     return Triple(nick, user, host)

--- a/lib/src/test/java/de/kuschku/libquassel/util/irc/HostmaskHelperTest.kt
+++ b/lib/src/test/java/de/kuschku/libquassel/util/irc/HostmaskHelperTest.kt
@@ -28,6 +28,22 @@ class HostmaskHelperTest {
   @Test
   fun testServer() {
     assertEquals("irc.freenode.org", HostmaskHelper.nick("irc.freenode.org"))
+    assertEquals("", HostmaskHelper.user("irc.freenode.org"))
+    assertEquals("", HostmaskHelper.host("irc.freenode.org"))
+  }
+
+  @Test
+  fun testAtNick() {
+    assertEquals("@nick", HostmaskHelper.nick("@nick!~ident@example.org"))
+    assertEquals("~ident", HostmaskHelper.user("@nick!~ident@example.org"))
+    assertEquals("example.org", HostmaskHelper.host("@nick!~ident@example.org"))
+  }
+
+  @Test
+  fun testReversedDelimiters() {
+    assertEquals("a", HostmaskHelper.nick("a@a!"))
+    assertEquals("", HostmaskHelper.user("a@a!"))
+    assertEquals("a!", HostmaskHelper.host("a@a!"))
   }
 
   @Test


### PR DESCRIPTION
Some examples of previously wrong outputs:

Input: `"a@a!"`
`(nick, user, host) == ("a@a!", "", "a!")`
`split == ("a@a!", "", "a!")`

Input: `"@nick!~ident@example.org"`
`(nick, user, host) == ("@nick", "~ident", "example.org")`
`split == ("@nick!~ident@example.org", "", "nick!~ident@example.org")`

So `split` and `nick` can give different results, which may be confusing. And that last example is the main reason why I want this change: I have a [modified](https://gist.github.com/oprypin/5c15d5bbde635196a66e340279423082#file-quassel-core-patch) Quassel core which can spit out nicknames starting with `@`, and then in Quasseldroid I see entire hostmasks in the chat view.

The main fix is in `split`: I make sure to split on the last `@` and also fix the mistake with `return Triple(mask, "", host)`, which was what caused me problems.

I also changed `nick`, `user`, `host` to be based on `split`, which may be controversial due to performance considerations, but it's really not possible to have them behave consistently with `split` without doing most of the same operations. I agree that the scenarios where they behave differently are completely unrealistic, so I suppose it's possible to undo that part, but then some test cases would need to be skipped and `split` would need to have separate unittests.