### PR TITLE
first try: add libravatarFallback

### DIFF
--- a/app/sampledata/features.json
+++ b/app/sampledata/features.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "RichMessages",
-      "description": "Required for seeing real names or IRCv3 or Gravatar avatars in messages"
+      "description": "Required for seeing real names or IRCv3, Gravatar, or Libravatar avatars in messages"
     },
     {
       "name": "BacklogFilterType",

--- a/app/src/main/java/de/kuschku/quasseldroid/settings/MessageSettings.kt
+++ b/app/src/main/java/de/kuschku/quasseldroid/settings/MessageSettings.kt
@@ -34,6 +34,7 @@ data class MessageSettings(
   val showAvatars: Boolean = true,
   val squareAvatars: Boolean = true,
   val showIRCCloudAvatars: Boolean = false,
+  val showLibravatarAvatars: Boolean = false,
   val showGravatarAvatars: Boolean = false,
   val showMatrixAvatars: Boolean = false,
   val largerEmoji: Boolean = false,

--- a/app/src/main/java/de/kuschku/quasseldroid/settings/Settings.kt
+++ b/app/src/main/java/de/kuschku/quasseldroid/settings/Settings.kt
@@ -134,6 +134,10 @@ object Settings {
         context.getString(R.string.preference_show_irccloud_avatars_key),
         MessageSettings.DEFAULT.showIRCCloudAvatars
       ),
+      showLibravatarAvatars = getBoolean(
+        context.getString(R.string.preference_show_libravatar_avatars_key),
+        MessageSettings.DEFAULT.showLibravatarAvatars
+      ),
       showGravatarAvatars = getBoolean(
         context.getString(R.string.preference_show_gravatar_avatars_key),
         MessageSettings.DEFAULT.showGravatarAvatars

--- a/app/src/main/java/de/kuschku/quasseldroid/util/avatars/AvatarHelper.kt
+++ b/app/src/main/java/de/kuschku/quasseldroid/util/avatars/AvatarHelper.kt
@@ -43,6 +43,9 @@ object AvatarHelper {
       (settings.showAvatars && settings.showIRCCloudAvatars).letIf {
         ircCloudFallback(ident, size)
       },
+      (settings.showAvatars && settings.showLibravatarAvatars).letIf {
+        libravatarFallback(realName, size)
+      },
       (settings.showAvatars && settings.showGravatarAvatars).letIf {
         gravatarFallback(realName, size)
       },
@@ -87,6 +90,21 @@ object AvatarHelper {
         "https://static.irccloud-cdn.com/avatar-redirect/$userId"
       )
     )
+  }
+
+  private fun libravatarFallback(realname: String, size: Int?): List<Avatar> {
+    return Patterns.AUTOLINK_EMAIL_ADDRESS
+      .findAll(realname)
+      .mapNotNull {
+        it.groups[1]?.value
+      }.map { email ->
+        val hash = Hex.encodeHexString(DigestUtils.md5(IrcCaseMappers.unicode.toLowerCase(email)))
+        if (size == null) {
+          "https://seccdn.libravatar.org/avatar/$hash?d=404"
+        } else {
+          "https://seccdn.libravatar.org/avatar/$hash?d=404&s=${size}"
+        }
+      }.map { Avatar.GravatarAvatar(it) }.toList()
   }
 
   private fun gravatarFallback(realname: String, size: Int?): List<Avatar> {

--- a/app/src/main/java/de/kuschku/quasseldroid/util/avatars/AvatarHelper.kt
+++ b/app/src/main/java/de/kuschku/quasseldroid/util/avatars/AvatarHelper.kt
@@ -99,10 +99,11 @@ object AvatarHelper {
         it.groups[1]?.value
       }.map { email ->
         val hash = Hex.encodeHexString(DigestUtils.md5(IrcCaseMappers.unicode.toLowerCase(email)))
+        val base = "https://seccdn.libravatar.org/avatar"
         if (size == null) {
-          "https://seccdn.libravatar.org/avatar/$hash?d=404"
+          "$base/$hash?d=404"
         } else {
-          "https://seccdn.libravatar.org/avatar/$hash?d=404&s=${size}"
+          "$base/$hash?d=404&s=${size}"
         }
       }.map { Avatar.LibravatarAvatar(it) }.toList()
   }

--- a/app/src/main/java/de/kuschku/quasseldroid/util/avatars/AvatarHelper.kt
+++ b/app/src/main/java/de/kuschku/quasseldroid/util/avatars/AvatarHelper.kt
@@ -99,6 +99,7 @@ object AvatarHelper {
         it.groups[1]?.value
       }.map { email ->
         val hash = Hex.encodeHexString(DigestUtils.md5(IrcCaseMappers.unicode.toLowerCase(email)))
+        val domain = IrcCaseMappers.unicode.toLowerCase(email).split('@')[1]
         val base = "https://seccdn.libravatar.org/avatar"
         if (size == null) {
           "$base/$hash?d=404"

--- a/app/src/main/java/de/kuschku/quasseldroid/util/avatars/AvatarHelper.kt
+++ b/app/src/main/java/de/kuschku/quasseldroid/util/avatars/AvatarHelper.kt
@@ -104,7 +104,7 @@ object AvatarHelper {
         } else {
           "https://seccdn.libravatar.org/avatar/$hash?d=404&s=${size}"
         }
-      }.map { Avatar.GravatarAvatar(it) }.toList()
+      }.map { Avatar.LibravatarAvatar(it) }.toList()
   }
 
   private fun gravatarFallback(realname: String, size: Int?): List<Avatar> {

--- a/app/src/main/java/de/kuschku/quasseldroid/util/helper/GlideHelper.kt
+++ b/app/src/main/java/de/kuschku/quasseldroid/util/helper/GlideHelper.kt
@@ -36,10 +36,11 @@ import de.kuschku.quasseldroid.viewmodel.data.Avatar
 fun GlideRequests.loadWithFallbacks(urls: List<Avatar>): GlideRequest<Drawable>? {
   fun fold(url: Avatar, fallback: RequestBuilder<Drawable>?): GlideRequest<Drawable> {
     return when (url) {
-      is Avatar.NativeAvatar   -> load(url.url)
-      is Avatar.GravatarAvatar -> load(url.url)
-      is Avatar.IRCCloudAvatar -> load(url.url)
-      is Avatar.MatrixAvatar   -> load(url)
+      is Avatar.NativeAvatar     -> load(url.url)
+      is Avatar.LibravatarAvatar -> load(url.url)
+      is Avatar.GravatarAvatar   -> load(url.url)
+      is Avatar.IRCCloudAvatar   -> load(url.url)
+      is Avatar.MatrixAvatar     -> load(url)
     }.let {
       if (fallback != null) it.error(fallback) else it
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -175,7 +175,7 @@
   <string name="label_feature_coresidehighlights">Benötigt für Hervorhebungen</string>
   <string name="label_feature_senderprefixes">Benötigt um die Präfixe (+, @) von Nutzern in Nachrichten zu sehen</string>
   <string name="label_feature_remotedisconnect">Benötigt um die Verbindung eigener Clients aus der Ferne zu trennen</string>
-  <string name="label_feature_richmessages">Benötigt um Echtnamen oder IRCv3 oder Gravatar-Avatare in Nachrichten zu sehen.</string>
+  <string name="label_feature_richmessages">Benötigt um Echtnamen oder IRCv3, Gravatar-Avatare, oder Libravatar-Avatare in Nachrichten zu sehen.</string>
   <string name="label_feature_backlogfiltertype">Benötigt um vergangene Benachrichtigungen nach dem Verbinden zu erhalten</string>
 
   <string name="label_feature_context_bufferactivitysync">Quasseldroid kann ungelesene Chats nicht hervorheben. Update deinen Core auf Quassel v0.13 um dies zu beheben.</string>

--- a/app/src/main/res/values-de/strings_preferences.xml
+++ b/app/src/main/res/values-de/strings_preferences.xml
@@ -123,6 +123,9 @@
   <string name="preference_show_irccloud_avatars_title">IRCCloud Avatare anzeigen</string>
   <string name="preference_show_irccloud_avatars_summary">Zeigt für Nutzer ohne Avatare den IRCCloud-Avatar an, falls verfügbar</string>
 
+  <string name="preference_show_libravatar_avatars_title">Libravatar Avatare anzeigen</string>
+  <string name="preference_show_libravatar_avatars_summary">Zeigt für Nutzer ohne Avatare den Libravatar-Avatar an, falls verfügbar</string>
+
   <string name="preference_show_gravatar_avatars_title">Gravatar Avatare anzeigen</string>
   <string name="preference_show_gravatar_avatars_summary">Zeigt für Nutzer ohne Avatare den Gravatar-Avatar an, falls verfügbar</string>
 

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -119,7 +119,7 @@
   <string name="label_feature_coresidehighlights">Requis pour les highlights</string>
   <string name="label_feature_senderprefixes">Requis pour voir les préfixes de modes (+, @) des utilisateurs dans les messages</string>
   <string name="label_feature_remotedisconnect">Requis pour déconnecter vos propres clients à distance</string>
-  <string name="label_feature_richmessages">Requis pour voir les vrais noms ou les avatars IRCv3 ou Gravatar dans les messages</string>
+  <string name="label_feature_richmessages">Requis pour voir les vrais noms ou les avatars IRCv3, Gravatar, ou Libravatar dans les messages</string>
   <string name="label_feature_backlogfiltertype">Requis pour recevoir des notifications antérieures après la connection</string>
 
   <string name="notification_channel_connection_title">Connection</string>

--- a/app/src/main/res/values-fr-rCA/strings_preferences.xml
+++ b/app/src/main/res/values-fr-rCA/strings_preferences.xml
@@ -98,6 +98,9 @@
   <string name="preference_show_irccloud_avatars_title">Montrer les Avatars IRCCloud</string>
   <string name="preference_show_irccloud_avatars_summary">Montrer, pour les utilisateurs sans avatars, leur avatar IRCCloud si possible</string>
 
+  <string name="preference_show_libravatar_avatars_title">Montrer les Avatars Libravatar</string>
+  <string name="preference_show_libravatar_avatars_summary">Montrer, pour les utilisateurs sans avatar, leur Libravatar si possible</string>
+
   <string name="preference_show_gravatar_avatars_title">Montrer les Avatars Gravatar</string>
   <string name="preference_show_gravatar_avatars_summary">Montrer, pour les utilisateurs sans avatar, leur Gravatar si possible</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -175,7 +175,7 @@
   <string name="label_feature_coresidehighlights">Necessario per le menzioni</string>
   <string name="label_feature_senderprefixes">Necessario per visualizzare i prefissi dei modi (+, @) degli utenti nei messaggi</string>
   <string name="label_feature_remotedisconnect">Necessario per la disconnessione da remoto dei tuoi client</string>
-  <string name="label_feature_richmessages">Necessario per visualizzare i nomi reali oppure gli avatar di IRCv3 o di Gravatar nei messaggi</string>
+  <string name="label_feature_richmessages">Necessario per visualizzare i nomi reali oppure gli avatar di IRCv3, di Libravatar, o di Gravatar nei messaggi</string>
   <string name="label_feature_backlogfiltertype">Necessario per ricevere le notifiche precedenti alla connessione</string>
 
   <string name="label_feature_context_bufferactivitysync">Quasseldroid non può evidenziare le chat non lette. Aggiorna il tuo core a Quassel v0.13 per risolvere.</string>

--- a/app/src/main/res/values-it/strings_preferences.xml
+++ b/app/src/main/res/values-it/strings_preferences.xml
@@ -123,6 +123,9 @@
   <string name="preference_show_irccloud_avatars_title">Mostra avatar di IRCCloud</string>
   <string name="preference_show_irccloud_avatars_summary">Per gli utenti privi di avatar mostra quello di IRCCloud, se disponibile</string>
 
+  <string name="preference_show_libravatar_avatars_title">Mostra avatar di Libravatar</string>
+  <string name="preference_show_libravatar_avatars_summary">Per gli utenti privi di avatar mostra quello di Libravatar, se disponibile</string>
+
   <string name="preference_show_gravatar_avatars_title">Mostra avatar di Gravatar</string>
   <string name="preference_show_gravatar_avatars_summary">Per gli utenti privi di avatar mostra quello di Gravatar, se disponibile</string>
 

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -175,7 +175,7 @@
   <string name="label_feature_coresidehighlights">Reikalinga paryškinimams</string>
   <string name="label_feature_senderprefixes">Reikalinga norint matyti naudotoju priešdėlių rėžimus (+, @) žinutėse</string>
   <string name="label_feature_remotedisconnect">Reikalinga jūsų klientų nuotoliniam atsijungimui</string>
-  <string name="label_feature_richmessages">Reikalinga norint matyti tikruosius vardus ar IRCv3/Gravatar Avatarus žinutėse</string>
+  <string name="label_feature_richmessages">Reikalinga norint matyti tikruosius vardus ar IRCv3/Gravatar/Libravatar Avatarus žinutėse</string>
   <string name="label_feature_backlogfiltertype">Reikalinga norint gauti senus pranešimus po prisijungimo</string>
 
   <string name="label_feature_context_bufferactivitysync">Quasseldroid negali pažymėti neskaitytų pokalbių. Atnaujinkite branduolį į Quassel v0.13, jog tai ištaisytumėte.</string>

--- a/app/src/main/res/values-lt/strings_preferences.xml
+++ b/app/src/main/res/values-lt/strings_preferences.xml
@@ -111,6 +111,9 @@
   <string name="preference_show_irccloud_avatars_title">Rodyti IRCCloud Avatarus</string>
   <string name="preference_show_irccloud_avatars_summary">Jei galima, vartotojams be Avataro rodys jų IRCCloud alternatyvą</string>
 
+  <string name="preference_show_libravatar_avatars_title">Rodyti Libravatar Avatarus</string>
+  <string name="preference_show_libravatar_avatars_summary">Jei galima, vartotojams be Avataro rodys jų Libravatar alternatyvą</string>
+
   <string name="preference_show_gravatar_avatars_title">Rodyti Gravatar Avatarus</string>
   <string name="preference_show_gravatar_avatars_summary">Jei galima, vartotojams be Avataro rodys jų Gravatar alternatyvą</string>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -173,7 +173,7 @@
   <string name="label_feature_coresidehighlights">Obrigatório para menções</string>
   <string name="label_feature_senderprefixes">Necessário para ver os modos de prefixo (+, @) dos utilizadores nas mensagens</string>
   <string name="label_feature_remotedisconnect">Necessário para desconexões remotas de seus próprios clientes</string>
-  <string name="label_feature_richmessages">Necessário para ver nomes reais ou avatares do IRCV3 ou do Gravatar em mensagens</string>
+  <string name="label_feature_richmessages">Necessário para ver nomes reais ou avatares do IRCV3, do Gravatar, ou do Libravatar em mensagens</string>
   <string name="label_feature_backlogfiltertype">Obrigatório para receber notificações passadas após a conexão</string>
 
   <string name="label_feature_context_bufferactivitysync">O Quasseldroid não pode destacar mensagens não lidas. Actualize seu núcleo para o Quassel v0.13 para resolver isso.</string>

--- a/app/src/main/res/values-pt/strings_preferences.xml
+++ b/app/src/main/res/values-pt/strings_preferences.xml
@@ -110,6 +110,9 @@
   <string name="preference_show_irccloud_avatars_title">Mostrar Avatares IRCCloud</string>
   <string name="preference_show_irccloud_avatars_summary">Mostra a utilizadores sem avatar, o avatar IRCCloud correspondente, se disponível</string>
 
+  <string name="preference_show_libravatar_avatars_title">Mostrar Avatares Libravatar</string>
+  <string name="preference_show_libravatar_avatars_summary">Mostra a utilizadores sem avatar, o avatar Libravatar correspondente, se disponível</string>
+
   <string name="preference_show_gravatar_avatars_title">Mostrar Avatares Gravatar</string>
   <string name="preference_show_gravatar_avatars_summary">Mostra a utilizadores sem avatar, o avatar Gravatar correspondente, se disponível</string>
 

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -126,7 +126,7 @@
   <string name="label_feature_coresidehighlights">Potrebno za isticanje</string>
   <string name="label_feature_senderprefixes">Potrebno za vidljivost prefiksa modova (+, @) korisnika u porukama</string>
   <string name="label_feature_remotedisconnect">Potrebno za daljinsko prekidanje veze sopstvenih klijenata</string>
-  <string name="label_feature_richmessages">Potrebno za vidljivost pravih imena ili IRCv3 ili Gravatar avatara u porukama</string>
+  <string name="label_feature_richmessages">Potrebno za vidljivost pravih imena ili IRCv3 ili Gravatar ili Libravatar avatara u porukama</string>
   <string name="label_feature_backlogfiltertype">Potrebno za primanje prošlih obaveštenja posle povezivanja</string>
 
   <string name="label_feature_context_missing">Vašem jezgru nedostaju funkcije potrebne za pravilno funkcionisanje Quasseldroid-a.</string>

--- a/app/src/main/res/values-sr/strings_preferences.xml
+++ b/app/src/main/res/values-sr/strings_preferences.xml
@@ -105,6 +105,9 @@
   <string name="preference_show_irccloud_avatars_title">Prikazuj IRCCloud avatare</string>
   <string name="preference_show_irccloud_avatars_summary">Prikazuje korisnicima bez avatara njihov IRCCloud avatar, ako je dostupan</string>
 
+  <string name="preference_show_libravatar_avatars_title">Prikazuj Libravatar avatare</string>
+  <string name="preference_show_libravatar_avatars_summary">Prikazuje korisnicima bez avatara njihov Libravatar, ako je dostupan</string>
+
   <string name="preference_show_gravatar_avatars_title">Prikazuj Gravatar avatare</string>
   <string name="preference_show_gravatar_avatars_summary">Prikazuje korisnicima bez avatara njihov Gravatar, ako je dostupan</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,7 +175,7 @@
   <string name="label_feature_coresidehighlights">Required for highlights</string>
   <string name="label_feature_senderprefixes">Required for seeing prefix modes (+, @) of users in messages</string>
   <string name="label_feature_remotedisconnect">Required for remote disconnects of your own clients</string>
-  <string name="label_feature_richmessages">Required for seeing real names or IRCv3 or Gravatar avatars in messages</string>
+  <string name="label_feature_richmessages">Required for seeing real names or IRCv3, Gravatar, or Libravatar avatars in messages</string>
   <string name="label_feature_backlogfiltertype">Required for receiving past notifications after connecting</string>
 
   <string name="label_feature_context_bufferactivitysync">Quasseldroid cannot highlight unread chats. Upgrade your core to Quassel v0.13 to resolve this.</string>

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -260,6 +260,10 @@
   <string name="preference_show_irccloud_avatars_title">Show IRCCloud Avatars</string>
   <string name="preference_show_irccloud_avatars_summary">Shows for users without avatar their IRCCloud fallback, if available</string>
 
+  <string name="preference_show_libravatar_avatars_key" translatable="false">show_libravatar_avatars</string>
+  <string name="preference_show_libravatar_avatars_title">Show Libravatar Avatars</string>
+  <string name="preference_show_libravatar_avatars_summary">Shows for users without avatar their Libravatar fallback, if available</string>
+  
   <string name="preference_show_gravatar_avatars_key" translatable="false">show_gravatar_avatars</string>
   <string name="preference_show_gravatar_avatars_title">Show Gravatar Avatars</string>
   <string name="preference_show_gravatar_avatars_summary">Shows for users without avatar their Gravatar fallback, if available</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -215,6 +215,12 @@
     <SwitchPreference
       android:defaultValue="false"
       android:dependency="@string/preference_show_avatars_key"
+      android:key="@string/preference_show_libravatar_avatars_key"
+      android:title="@string/preference_show_libravatar_avatars_title" />
+
+    <SwitchPreference
+      android:defaultValue="false"
+      android:dependency="@string/preference_show_avatars_key"
       android:key="@string/preference_show_gravatar_avatars_key"
       android:title="@string/preference_show_gravatar_avatars_title" />
 

--- a/app/src/test/java/de/kuschku/quasseldroid/util/AvatarHelperTest.kt
+++ b/app/src/test/java/de/kuschku/quasseldroid/util/AvatarHelperTest.kt
@@ -71,6 +71,48 @@ class AvatarHelperTest {
   }
 
   @Test
+  fun testLibravatarAvatars() {
+    val message = MessageData.of(
+      messageId = MsgId(1),
+      time = Instant.now(),
+      type = Message_Type.of(Message_Type.Plain),
+      flag = Message_Flag.of(),
+      bufferId = BufferId(0),
+      networkId = NetworkId(0),
+      currentBufferId = BufferId(0),
+      currentBufferType = Buffer_Type.of(),
+      sender = "justJanne",
+      senderPrefixes = "",
+      realName = "Janne Mareike Koschinski <janne@kuschku.de>",
+      avatarUrl = "",
+      content = "Lorem Ipsum I Dolor Sit Amet",
+      ignored = false
+    )
+
+    assert(
+      AvatarHelper.avatar(
+        MessageSettings(
+          showLibravatarAvatars = true,
+          showIRCCloudAvatars = true
+        ),
+        message
+      ).contains(
+        Avatar.LibravatarAvatar("https://seccdn.libravatar.org/avatar/81128f11cae692bc486e3f88b854ddf1?d=404")
+      )
+    )
+
+    assert(
+      AvatarHelper.avatar(
+        MessageSettings(
+          showLib2568217a2207f06de59d0fcc1f14b8bc?s=160&d=404ravatarAvatars = false,
+          showIRCCloudAvatars = false
+        ),
+        message
+      ).isEmpty()
+    )
+  }
+
+  @Test
   fun testIrcCloudAvatars() {
     val message = MessageData.of(
       messageId = MsgId(1),

--- a/app/src/test/java/de/kuschku/quasseldroid/util/AvatarHelperTest.kt
+++ b/app/src/test/java/de/kuschku/quasseldroid/util/AvatarHelperTest.kt
@@ -104,7 +104,7 @@ class AvatarHelperTest {
     assert(
       AvatarHelper.avatar(
         MessageSettings(
-          showLib2568217a2207f06de59d0fcc1f14b8bc?s=160&d=404ravatarAvatars = false,
+          showLibravatarAvatars = false,
           showIRCCloudAvatars = false
         ),
         message

--- a/viewmodel/src/main/java/de/kuschku/quasseldroid/viewmodel/data/Avatar.kt
+++ b/viewmodel/src/main/java/de/kuschku/quasseldroid/viewmodel/data/Avatar.kt
@@ -24,6 +24,7 @@ import java.io.Serializable
 sealed class Avatar : Serializable {
   data class NativeAvatar(val url: String) : Avatar()
   data class IRCCloudAvatar(val url: String) : Avatar()
+  data class LibravatarAvatar(val url: String) : Avatar()
   data class GravatarAvatar(val url: String) : Avatar()
   data class MatrixAvatar(val userId: String, val size: Int?) : Avatar()
 }


### PR DESCRIPTION
Still missing:
- discovering selfhosted libravatar via SRV records https://wiki.libravatar.org/api/ -- this needs dns resolution to find records of type `SRV` targeting `_avatars-sec._tcp` on `domain` (and possibly `_avatars._tcp` for plain HTTP fallback?). i don't know what imports/syntax are necessary to do this (dnsjava? minidns?), so i have only added the base url and domain split; someone else can add the try-except for SRV lookup.

also not sure if the test is correct; i didn't know which settings to include so i would appreciate a review on https://github.com/justjanne/QuasselDroid-ng/pull/13/commits/f1baabdf5d9291878db6c2fde3e966ca60385a05 particularly. also https://github.com/justjanne/QuasselDroid-ng/pull/13/commits/04d10c6d27fd00a00dbf25c087d24f0a884b7982 should say `values-it strings` instead of `values-fr-rCA strings` but i forgot to change the commit title when copypasting.

If any other changes are needed that I missed, please let me know as I have never worked with Android / Java / Kotlin before, so I just did a search for "gravatar" in this repo and copied/adapted what i could find.